### PR TITLE
feat: add remove file prompt

### DIFF
--- a/prompts/file.go
+++ b/prompts/file.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pterm/pterm"
 	"github.com/spectrocloud-labs/prompts-tui/prompts/mocks"
 )
 
@@ -181,4 +182,25 @@ func FilterLines(lines []string, validate func(input string) error) ([]string, e
 	}
 
 	return out, nil
+}
+
+// RemoveFile prompts a user whether they want to remove a file. Removes the file if the user wants
+// it to be removed. If no error is encountered, prints a message telling the user the result. In
+// case of error, does not print any further message and returns the error to be handled by caller.
+func RemoveFile(path string, defaultVal bool) error {
+	remove, err := ReadBool(fmt.Sprintf("Remove file %s from disk", path), defaultVal)
+	if err != nil {
+		return err
+	}
+
+	if remove {
+		if err := os.Remove(path); err != nil {
+			return err
+		}
+		pterm.Info.Println("File removed.")
+	} else {
+		pterm.Info.Println("File kept.")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Adds a prompt that can be used to ask a user whether they want a file to be removed from disk. Includes support for default value, which can be used for example to force the prompt to default to true in case of files that contains sensitive data that we think should default to being removed.

Did not add automated tests because we have none so far for the file prompts. But manually tested it with a small tester program:

```go
package main

import (
	"fmt"

	"github.com/spectrocloud-labs/prompts-tui/prompts"
)

const (
	filePath = "file.txt"
)

func main() {
	if err := prompts.RemoveFile("file.txt", true); err != nil {
		panic(fmt.Errorf("failed to remove file %s via prompt: %w", filePath, err))
	}
}
```

```
~/prompts-tui-tester > go run main.go 
Remove file file.txt from disk? [Y/n]: No
 INFO  File kept.
```

```
~/prompts-tui-tester > go run main.go 
Remove file file.txt from disk? [Y/n]: Yes
 INFO  File removed.
```

```
~/prompts-tui-tester > go run main.go 
Remove file file.txt from disk? [Y/n]: Yes
panic: failed to remove file file.txt via prompt: remove file.txt: no such file or directory

goroutine 1 [running]:
main.main()
        /home/matt/prompts-tui-tester/main.go:15 +0x93
exit status 2
```